### PR TITLE
Niet heel veel op aan te merken

### DIFF
--- a/week3/static/app.js
+++ b/week3/static/app.js
@@ -6,7 +6,17 @@
     templateCurrent: Handlebars.compile(document.querySelector('#template-current').innerHTML),
     templateHourly: Handlebars.compile(document.querySelector('#template-hourly').innerHTML),
     url(parameter) { return `https://api.wunderground.com/api/${config.API_KEY}/${parameter}/q/autoip.json`;},
-    html: ''
+    html: '',
+    // Zoiets    
+    date: {
+      date: new Date(),
+      month: '0' + date.getMonth(),
+      minutes: '0' + date.getMinutes(),
+      seconds: '0' + date.getSeconds(),
+      month: '0' + date.getMonth()
+      // Etc..etc..
+      // Maar weet niet of het dan nog werkt..
+    }
   };
 
   const emptyState = {


### PR DESCRIPTION
- Je mist alleen comments.
- Wanneer ik bijvoorbeeld op de zon filter klik bij "hourly" staat er no data. Komt dat omdat het niet zonnig wordt? 
In dat geval kan je beter aangeven dat er geen zonnige dagen zijn of iets dergelijks, in plaats van "no data".
- Datum objecten op een hoger niveau oproepen -> bijv in app?
 Want je gebruikt het in meerdere objecten.